### PR TITLE
Test datadog-ci-rb PR #457: GitHub Actions numeric job ID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,33 @@ jobs:
           languages: ruby
           api_key: ${{ secrets.DD_API_KEY }}
           site: datadoghq.eu
+      - name: Check runner diagnostics paths
+        run: |
+          echo "=== Checking common runner diag paths ==="
+          echo "RUNNER_WORKSPACE: $RUNNER_WORKSPACE"
+          echo "HOME: $HOME"
+
+          # Check hardcoded path
+          echo "=== /home/runner/actions-runner/_diag ==="
+          ls -la /home/runner/actions-runner/_diag 2>&1 || echo "Path does not exist"
+
+          # Check alternative paths
+          echo "=== /home/runner/_diag ==="
+          ls -la /home/runner/_diag 2>&1 || echo "Path does not exist"
+
+          echo "=== ~/actions-runner/_diag ==="
+          ls -la ~/actions-runner/_diag 2>&1 || echo "Path does not exist"
+
+          # Find any Worker_*.log files
+          echo "=== Finding Worker_*.log files ==="
+          find /home/runner -name "Worker_*.log" -type f 2>/dev/null | head -5 || echo "No Worker logs found"
+          find / -name "Worker_*.log" -type f 2>/dev/null | head -5 || echo "No Worker logs found"
+
+          # Check env vars for runner path
+          echo "=== Environment variables ==="
+          env | grep -i runner || true
+          env | grep -i actions || true
+
       - name: Run tests
         run: bundle exec rake
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,29 +44,30 @@ jobs:
       - name: Check runner diagnostics paths
         run: |
           echo "=== Checking common runner diag paths ==="
-          echo "RUNNER_WORKSPACE: $RUNNER_WORKSPACE"
-          echo "HOME: $HOME"
 
-          # Check hardcoded path
-          echo "=== /home/runner/actions-runner/_diag ==="
+          # Check paths used by datadog-ci (JS)
+          echo "=== /home/runner/actions-runner/cached/_diag (SaaS path) ==="
+          ls -la /home/runner/actions-runner/cached/_diag 2>&1 || echo "Path does not exist"
+
+          echo "=== /home/runner/actions-runner/_diag (self-hosted path) ==="
           ls -la /home/runner/actions-runner/_diag 2>&1 || echo "Path does not exist"
 
-          # Check alternative paths
-          echo "=== /home/runner/_diag ==="
-          ls -la /home/runner/_diag 2>&1 || echo "Path does not exist"
+          # Find _diag directories
+          echo "=== Finding _diag directories ==="
+          find /home/runner -name "_diag" -type d 2>/dev/null | head -10 || echo "No _diag dirs found"
 
-          echo "=== ~/actions-runner/_diag ==="
-          ls -la ~/actions-runner/_diag 2>&1 || echo "Path does not exist"
-
-          # Find any Worker_*.log files
-          echo "=== Finding Worker_*.log files ==="
-          find /home/runner -name "Worker_*.log" -type f 2>/dev/null | head -5 || echo "No Worker logs found"
-          find / -name "Worker_*.log" -type f 2>/dev/null | head -5 || echo "No Worker logs found"
-
-          # Check env vars for runner path
-          echo "=== Environment variables ==="
-          env | grep -i runner || true
-          env | grep -i actions || true
+          # If found, show contents
+          for dir in $(find /home/runner -name "_diag" -type d 2>/dev/null); do
+            echo "=== Contents of $dir ==="
+            ls -la "$dir" 2>&1 || true
+            # Show Worker log content if exists
+            for wlog in "$dir"/Worker_*.log; do
+              if [ -f "$wlog" ]; then
+                echo "=== Contents of $wlog (first 50 lines) ==="
+                head -50 "$wlog"
+              fi
+            done
+          done
 
       - name: Run tests
         run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,4 @@ jobs:
         run: bundle exec rake
         env:
           DD_TEST_SESSION_NAME: sidekiq-ruby-${{ matrix.ruby }}-redis-${{ matrix.redis }}
+          DD_TRACE_DEBUG: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,34 +41,6 @@ jobs:
           languages: ruby
           api_key: ${{ secrets.DD_API_KEY }}
           site: datadoghq.eu
-      - name: Check runner diagnostics paths
-        run: |
-          echo "=== Checking common runner diag paths ==="
-
-          # Check paths used by datadog-ci (JS)
-          echo "=== /home/runner/actions-runner/cached/_diag (SaaS path) ==="
-          ls -la /home/runner/actions-runner/cached/_diag 2>&1 || echo "Path does not exist"
-
-          echo "=== /home/runner/actions-runner/_diag (self-hosted path) ==="
-          ls -la /home/runner/actions-runner/_diag 2>&1 || echo "Path does not exist"
-
-          # Find _diag directories
-          echo "=== Finding _diag directories ==="
-          find /home/runner -name "_diag" -type d 2>/dev/null | head -10 || echo "No _diag dirs found"
-
-          # If found, show contents
-          for dir in $(find /home/runner -name "_diag" -type d 2>/dev/null); do
-            echo "=== Contents of $dir ==="
-            ls -la "$dir" 2>&1 || true
-            # Show Worker log content if exists
-            for wlog in "$dir"/Worker_*.log; do
-              if [ -f "$wlog" ]; then
-                echo "=== Contents of $wlog (first 50 lines) ==="
-                head -50 "$wlog"
-              fi
-            done
-          done
-
       - name: Run tests
         run: bundle exec rake
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,11 @@ jobs:
         run: |
           DIAG_PATH="/home/runner/actions-runner/cached/_diag"
           if [ -d "$DIAG_PATH" ]; then
-            echo "=== Looking for check_run_id in Worker logs ==="
-            grep -r "check_run_id" "$DIAG_PATH" || echo "check_run_id not found in any file"
-            echo "=== Full Worker log content ==="
-            cat "$DIAG_PATH"/Worker_*.log | head -200
+            echo "=== Lines containing check_run_id in Worker logs ==="
+            grep "check_run_id" "$DIAG_PATH"/Worker_*.log | head -20
+            echo ""
+            echo "=== Looking for job.d structure ==="
+            grep '"job"' "$DIAG_PATH"/Worker_*.log | head -10
           else
             echo "Diag path not found: $DIAG_PATH"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,17 @@ jobs:
           languages: ruby
           api_key: ${{ secrets.DD_API_KEY }}
           site: datadoghq.eu
+      - name: Check Worker log for check_run_id
+        run: |
+          DIAG_PATH="/home/runner/actions-runner/cached/_diag"
+          if [ -d "$DIAG_PATH" ]; then
+            echo "=== Looking for check_run_id in Worker logs ==="
+            grep -r "check_run_id" "$DIAG_PATH" || echo "check_run_id not found in any file"
+            echo "=== Full Worker log content ==="
+            cat "$DIAG_PATH"/Worker_*.log | head -200
+          else
+            echo "Diag path not found: $DIAG_PATH"
+          fi
       - name: Run tests
         run: bundle exec rake
         env:

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "bigdecimal"
 # testing of test optimization
 # gem "datadog-ci", path: "../../p/datadog-ci-rb" # local gem copy
 # gem "datadog-ci" # latest released
-gem "datadog-ci", github: "DataDog/datadog-ci-rb", ref: "main" # specific branch
+gem "datadog-ci", github: "DataDog/datadog-ci-rb", ref: "anmarchenko/fix_github_job_id" # PR #457
 
 group :test do
   gem "maxitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DataDog/datadog-ci-rb.git
-  revision: 278155308e2abbebce529d6526ab4c5d9f6ded61
-  ref: main
+  revision: 99f6dcae15e1f24ec12073cb1e05a9d478e28d9c
+  ref: anmarchenko/fix_github_job_id
   specs:
     datadog-ci (1.26.0)
       datadog (~> 2.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/datadog-ci-rb.git
-  revision: ba6f13d3d3e552904bf7e3853c53c3302c78eea0
+  revision: 364982ad61062d6766e4990611296dc311edceac
   ref: anmarchenko/fix_github_job_id
   specs:
     datadog-ci (1.26.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/datadog-ci-rb.git
-  revision: 99f6dcae15e1f24ec12073cb1e05a9d478e28d9c
+  revision: ba6f13d3d3e552904bf7e3853c53c3302c78eea0
   ref: anmarchenko/fix_github_job_id
   specs:
     datadog-ci (1.26.0)
@@ -68,10 +68,10 @@ GEM
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
-    datadog (2.25.0)
+    datadog (2.26.0)
       cgi
-      datadog-ruby_core_source (~> 3.5, >= 3.5.0)
-      libdatadog (~> 24.0.1.1.0)
+      datadog-ruby_core_source (~> 3.5, >= 3.5.1)
+      libdatadog (~> 25.0.0.1.0)
       libddwaf (~> 1.30.0.0.0)
       logger
       msgpack
@@ -95,8 +95,8 @@ GEM
       reline (>= 0.3.8)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
-    libdatadog (24.0.1.1.0)
-    libdatadog (24.0.1.1.0-x86_64-linux)
+    libdatadog (25.0.0.1.0)
+    libdatadog (25.0.0.1.0-x86_64-linux)
     libddwaf (1.30.0.0.0-arm64-darwin)
       ffi (~> 1.0)
     libddwaf (1.30.0.0.0-x86_64-linux)


### PR DESCRIPTION
## Summary

Testing datadog-ci-rb PR #457 which extracts the numeric job ID from GitHub Actions runner diagnostics for accurate `ci.job.url` values.

**PR under test**: https://github.com/DataDog/datadog-ci-rb/pull/457

## What to verify

After GitHub Actions completes, check the Datadog UI to verify:
- `ci.job.url` contains the numeric job ID format: `https://github.com/REPO/actions/runs/RUN_ID/job/NUMERIC_JOB_ID`
- Instead of the old generic format: `https://github.com/REPO/commit/SHA/checks`

## Cleanup

This PR will be closed without merging after testing is complete.